### PR TITLE
WIP: Demonstrate deserializing String -> NaiveDate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ impl FitbitClient {
         headers.set(Authorization(Bearer {
             token: token.0.access_token,
         }));
-        headers.set(UserAgent::new("fitbit-grabber-rs (0.1.0)"));
+        headers.set(UserAgent::new("fitbit-rs (0.1.0)"));
 
         let client = reqwest::Client::builder()
             .default_headers(headers)
@@ -104,7 +104,6 @@ impl FitbitAuth {
     pub fn new(client_id: &str, client_secret: &str) -> FitbitAuth {
         let auth_url = "https://www.fitbit.com/oauth2/authorize";
         let token_url = "https://api.fitbit.com/oauth2/token";
-        // let token_url = "http://localhost:8080";
 
         // Set up the config for the Github OAuth2 process.
         let mut config = OAuth2Config::new(client_id, client_secret, auth_url, token_url);
@@ -120,6 +119,7 @@ impl FitbitAuth {
 
         // This example will be running its own server at localhost:8080.
         // See below for the server implementation.
+        // TODO configurable redirect?
         config = config.set_redirect_url("http://localhost:8080");
 
         FitbitAuth(config)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod body;
 pub mod date;
 pub mod errors;
 pub mod query;
+pub mod serializers;
 pub mod user;
 
 use errors::Error;
@@ -56,10 +57,12 @@ impl FitbitClient {
     }
 
     pub fn user(&self) -> Result<String> {
-        let url = self.base
+        let url = self
+            .base
             .join("user/-/profile.json")
             .map_err(|e| Error::Url(e))?;
-        Ok(self.client
+        Ok(self
+            .client
             .request(reqwest::Method::Get, url)
             .send()
             .and_then(|mut r| r.text())?)
@@ -84,7 +87,8 @@ impl FitbitClient {
             date.format("%Y-%m-%d")
         );
         let url = self.base.join(&path).map_err(|e| Error::Url(e))?;
-        Ok(self.client
+        Ok(self
+            .client
             .request(Method::Get, url)
             .send()
             .and_then(|mut r| r.text())
@@ -178,7 +182,8 @@ impl FitbitAuth {
 
     pub fn exchange_refresh_token(&self, token: Token) -> Result<oauth2::Token> {
         match token.0.refresh_token {
-            Some(t) => self.0
+            Some(t) => self
+                .0
                 .exchange_refresh_token(t)
                 .map_err(|e| Error::AuthToken(e)),
             None => Err(Error::RefreshTokenMissing),

--- a/src/serializers.rs
+++ b/src/serializers.rs
@@ -1,0 +1,28 @@
+pub mod naive_date {
+    use chrono::NaiveDate;
+    use serde::{self, Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S>(date: &Option<NaiveDate>, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if let Some(ref d) = *date {
+            return s.serialize_str(&d.format("%Y-%m-%d").to_string());
+        }
+        s.serialize_none()
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<NaiveDate>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s: Option<String> = Option::deserialize(deserializer)?;
+        if let Some(s) = s {
+            return Ok(Some(
+                NaiveDate::parse_from_str(&s, "%Y-%m-%d").map_err(serde::de::Error::custom)?,
+            ));
+        }
+
+        Ok(None)
+    }
+}


### PR DESCRIPTION
The weight series json object returned by fitbit contains two strings, for example

```json
{ "dateTime": "2018-01-01", "value": "70" }
```
Computation in Rust itself isn't possible unless we convert these to a `NaiveDate` and a float, respectively.

Here is an example of using a custom module "shim" to deserialize an `Option<NaiveDate>` from a string. A float deserialization would look similar. An `Option` seems more polite than either 1) panicking internally or 2) returning some weird "0-value" for the date. I've included the code under a potential library module `serializers`. I imagine we could nest a few `mods` in that file.

What do you think? 
